### PR TITLE
140718855: Use ffmpeg to preprocess audio

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 # encoding: utf-8
 source 'https://rubygems.org'
 
-gem 'karafka'
 gem 'activerecord'
 gem 'activesupport'
-gem 'rubocop', '~> 0.47.1', require: false
+gem 'karafka'
+gem 'streamio-ffmpeg'
 
 group :development do
   gem 'database_cleaner', '1.5.3'
@@ -13,6 +13,7 @@ group :development do
   gem 'guard-rspec', require: false
   gem 'guard-rubocop'
   gem 'pry'
+  gem 'rubocop', '~> 0.47.1', require: false
 end
 
 # Database Models

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/birdfeed/kagu.git
-  revision: 9cea98958a57915883351436bb543b0dd236a8f8
+  revision: 112ef5a291923bc024947f7b4dba1d1f83b0c0da
   specs:
-    kagu (0.0.9)
+    kagu (0.0.10)
       activerecord
       activesupport
       devise
@@ -69,7 +69,7 @@ GEM
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     database_cleaner (1.5.3)
-    devise (4.2.0)
+    devise (4.2.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.1)
@@ -126,8 +126,9 @@ GEM
     method_source (0.8.2)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    multi_json (1.12.1)
     nenv (0.3.0)
-    nokogiri (1.7.0.1)
+    nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -136,7 +137,7 @@ GEM
     orm_adapter (0.5.0)
     parser (2.4.0.0)
       ast (~> 2.2)
-    pg (0.19.0)
+    pg (0.20.0)
     pocketsphinx-ruby (0.3.0)
       ffi (>= 1.9)
     powerpack (0.1.1)
@@ -197,6 +198,8 @@ GEM
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
     slop (3.6.0)
+    streamio-ffmpeg (3.0.2)
+      multi_json (~> 1.8)
     thor (0.19.4)
     thread_safe (0.3.6)
     timers (4.1.2)
@@ -234,6 +237,7 @@ DEPENDENCIES
   pocketsphinx-ruby (= 0.3.0)
   pry
   rubocop (~> 0.47.1)
+  streamio-ffmpeg
 
 BUNDLED WITH
    1.14.4

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 # ubuntu is an ancient word for outdated dependencies
 dependencies:
   pre:
+      - sudo apt-get update; sudo apt-get install ffmpeg;
       - git clone git@github.com:cmusphinx/sphinxbase.git
       - git clone git@github.com:cmusphinx/pocketsphinx.git
       - cd sphinxbase; ./autogen.sh; make; sudo make install;

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 # ubuntu is an ancient word for outdated dependencies
 dependencies:
   pre:
+      - sudo add-apt-repository ppa:mc3man/trusty-media -y;
       - sudo apt-get update; sudo apt-get install ffmpeg;
       - git clone git@github.com:cmusphinx/sphinxbase.git
       - git clone git@github.com:cmusphinx/pocketsphinx.git

--- a/lib/services/samples/speech_recognition.rb
+++ b/lib/services/samples/speech_recognition.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'pocketsphinx-ruby'
+require 'streamio-ffmeg'
 
 module Services
   module Samples
@@ -11,20 +12,38 @@ module Services
       end
 
       def compute_hypothesis(sample)
-        recognizer.decode(fetch_buffer(sample.s3_url))
-        recognizer.hypothesis
+        prepare_buffer(sample.s3_url)
+        recognizer.decode(wav_tmpfile)
+        recognizer.hypothesis.tap do
+          File.delete(wav_tmpfile)
+          @tf_path = nil
+        end
       end
 
       private
 
-      def fetch_buffer(s3_url)
-        Adapters::S3.file_to_buffer(s3_url)
+      attr_reader :tf_path
+
+      def prepare_buffer(s3_url)
+        # Dump the buffer to a temporary file
+        tempfile = Tempfile.new('sphinxtemp')
+        tempfile.write(Adapters::S3.file_to_buffer(s3_url))
+        @tf_path = tempfile.path
+
+        # ffmpeg it into PocketSphinx specs
+        ff = FFMPEG::Movie.new(@tf_path)
+        ff.transcode("#{tf_path}-wv", %w(-ar 1600 -ac 1)
+        tempfile.unlink
       end
 
       def recognizer
         @recognizer ||= ::Pocketsphinx::Decoder.new(
           ::Pocketsphinx::Configuration.default
         )
+      end
+
+      def wav_tmpfile
+        "#{@tf_path}-wv"
       end
     end
   end

--- a/spec/lib/services/samples/speech_recognition_spec.rb
+++ b/spec/lib/services/samples/speech_recognition_spec.rb
@@ -1,5 +1,4 @@
 describe Services::Samples::SpeechRecognition do 
-
   let(:file_url) { 'spec/fixtures/sound/hello.wav' }
   let(:hello_sound) { File.open(file_url) }
   let(:sample) { FactoryGirl.create(:sample, s3_url: file_url) }
@@ -11,6 +10,12 @@ describe Services::Samples::SpeechRecognition do
     end
 
     let(:parsed_speech) { described_class.compute_hypothesis(sample) }
+
+    it 'should invoke ffmpeg for conversion' do 
+      expect_any_instance_of(FFMPEG::Movie)
+        .to receive(:transcode).and_call_original
+      parsed_speech
+    end
 
     it 'should attempt an inference' do
       expect(parsed_speech).to be_a(Pocketsphinx::Decoder::Hypothesis)


### PR DESCRIPTION
- New dependency for CI on `ffmpeg`\
- `ffmpeg-streamio` is just a wrapper around the CLI utility so there's no `libffi` dependency as far as I'm aware