### PR TITLE
146996217: Don't delete S3 bucket!

### DIFF
--- a/app/controllers/sample/delete_from_s3.rb
+++ b/app/controllers/sample/delete_from_s3.rb
@@ -5,7 +5,7 @@ module Controllers
       def perform_async
         object = Kagu::Adapters::S3.object_by_key(message[:s3_key])
         return unless object.present?
-        object.delete
+        object.delete if object.present? && object.is_a?(Aws::S3::Object)
       end
     end
   end


### PR DESCRIPTION
The type check should be enough to ensure we only invoke `#delete` on actual `Aws::S3::Object` objects. 